### PR TITLE
Implement AmongUsClient, fix shipstatus selection, read game code and meeting state

### DIFF
--- a/AmongUsMemory/Cheese.cs
+++ b/AmongUsMemory/Cheese.cs
@@ -121,7 +121,7 @@ namespace HamsterCheese.AmongUsMemory
             return amongUsClient;
         }
 
-        public static String getGameCode()
+        public static String GetGameCode()
         {
             try
             {
@@ -137,7 +137,7 @@ namespace HamsterCheese.AmongUsMemory
             return null;
         }
 
-        public static int getMeetingStatus()
+        public static int GetMeetingStatus()
         {
             try
             {

--- a/AmongUsMemory/EngineOffset.cs
+++ b/AmongUsMemory/EngineOffset.cs
@@ -1,11 +1,15 @@
 namespace HamsterCheese.AmongUsMemory
 {
     public sealed class Pattern
-    { 
+    {
         public static string PlayerControl_Pointer = "GameAssembly.dll+1C57F7C";
         public static string ShipStatus_Pointer = "GameAssembly.dll+1C56C38";
         public static string AmongusClient_Pointer = "GameAssembly.dll+1C57F54";
-        public static string PlayerControl_GetData = "55 8B EC 80 3D A9 D1 ??"; 
+
+        public static string GameCode_Field_Pointer = "GameAssembly.dll+1af20fc,0x5C,0,0x20,0x28"; // gameCode: [28254460, 92, 0, 32, 40],
+        public static string MeetingHud_State_Field_Pointer = "GameAssembly.dll+1c573a4,0x5C,0,0x8,0x84,0x0"; // meetingHud: [29717412, 92, 0], meetingHudCachePtr: [8], meetingHudState: [132],
+
+        public static string PlayerControl_GetData = "55 8B EC 80 3D A9 D1 ??";
     }
 } 
   

--- a/YourCheese/Program.cs
+++ b/YourCheese/Program.cs
@@ -14,13 +14,21 @@ namespace YourCheese
         static int tableWidth = 75;
 
        
-        static List<PlayerData> playerDatas = new List<PlayerData>(); 
+        static List<PlayerData> playerDatas = new List<PlayerData>();
+        static AmongUsClient client;
+        static ShipStatus ship;
+        static String gamecode;
+        static int meeting_status;
+
         static void UpdateCheat()
         {
-       
             while (true)
             { 
                 Console.Clear();
+                Console.WriteLine($"Game code: {gamecode} (ID {client.GameId})");
+
+                Console.WriteLine($"Game mode: {client.GameMode}, state: {client.GameState}, Meeting state: {meeting_status}");
+
                 Console.WriteLine("Test Read Player Datas..");
                 PrintRow("offset", "Name", "OwnerId", "PlayerId", "spawnid", "spawnflag");
                 PrintLine();
@@ -61,8 +69,10 @@ namespace YourCheese
 
 
                     playerDatas = HamsterCheese.AmongUsMemory.Cheese.GetAllPlayers();
-                    
-                  
+                    client = HamsterCheese.AmongUsMemory.Cheese.GetClient();
+                    ship = HamsterCheese.AmongUsMemory.Cheese.GetShipStatus();
+                    gamecode = HamsterCheese.AmongUsMemory.Cheese.GetGameCode();
+                    meeting_status = HamsterCheese.AmongUsMemory.Cheese.GetMeetingStatus();
                  
                     foreach (var player in playerDatas)
                     {


### PR DESCRIPTION
I'm not sure this is necessarily the best way to do some of this. The shipstatus selection fix is taken from a suggestion by AlexisAG in #57 and seems to hold up okay when tested, the game code and meeting state fields are necessary for my purposes and I got those references via CrewLink but I'm unsure if the meeting should be a struct of some sort instead.